### PR TITLE
build: I think the icu-uc should at least be Requires.private as the

### DIFF
--- a/icu-le-hb.pc.in
+++ b/icu-le-hb.pc.in
@@ -6,7 +6,6 @@ includedir=@includedir@
 Name: icu-le-hb
 Description: ICU Layout Engine API on top of HarfBuzz shaping library
 Version: @VERSION@
-Requires.private: harfbuzz
-Requires.private: icu-uc
+Requires.private: harfbuzz icu-uc
 Libs: -L${libdir} -licu-le-hb
 Cflags: -I${includedir}/icu-le-hb


### PR DESCRIPTION
end app doesn't need to link against this icu-uc. Fixes https://github.com/behdad/icu-le-hb/issues/4
Not totally happy with this, but seems like an improvement.
