### PR TITLE
fix for compilation with MSVC

### DIFF
--- a/src/LayoutEngine.cpp
+++ b/src/LayoutEngine.cpp
@@ -268,8 +268,8 @@ le_int32 LayoutEngine::layoutChars(const LEUnicode chars[], le_int32 offset, le_
     hb_buffer_set_flags (fHbBuffer, (hb_buffer_flags_t)
                          ((offset == 0 ? HB_BUFFER_FLAG_BOT : 0) |
                           (offset + count == max ? HB_BUFFER_FLAG_EOT : 0)));
-    hb_buffer_add_utf16 (fHbBuffer, chars, max, offset, 0);
-    hb_buffer_add_utf16 (fHbBuffer, chars + offset, max - offset, 0, count);
+    hb_buffer_add_utf16 (fHbBuffer, (const uint16_t*)chars, max, offset, 0);
+    hb_buffer_add_utf16 (fHbBuffer, (const uint16_t*)(chars + offset), max - offset, 0, count);
 
     /* TODO Support features? */
     hb_shape (fHbFont, fHbBuffer, NULL, 0);


### PR DESCRIPTION
LEUnicode is wchar_t when compiling with MSVC, and wchar_t* does not convert to uint16_t* without a cast.