### PR TITLE
build: don't underlink icu-uc

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -24,6 +24,7 @@ libicu_le_hb_la_CPPFLAGS = \
 	$(NULL)
 libicu_le_hb_la_LIBADD = \
 	$(HARFBUZZ_LIBS) \
+	$(ICU_LIBS) \
 	$(NULL)
 
 libicu_le_hb_la_SOURCES = \


### PR DESCRIPTION
```c++
$ echo 'int main() { }' | cc `pkg-config --libs icu-le-hb` -xc -
/usr/local/lib/libicu-le-hb.so: undefined reference to `icu::UMemory::operator new(unsigned long)'
/usr/local/lib/libicu-le-hb.so: undefined reference to `icu::UObject::~UObject()'
/usr/local/lib/libicu-le-hb.so: undefined reference to `icu::UMemory::operator delete(void*)'
/usr/local/lib/libicu-le-hb.so: undefined reference to `typeinfo for icu::UObject'
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```